### PR TITLE
- docker-compose: mount ./cv-site into proxy at /srv/cv (read-only)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,24 +1,23 @@
 {
-  # absolutely disable HTTPS at the origin
+  # Cloudflare Tunnel terminates TLS; keep origin HTTP-only.
   auto_https off
 }
 
-# one HTTP-only server
-http://:80 {
-  # CV vhost (match by Host header)
-  @cv host cv.blainweb.com
-  handle @cv {
-    root * /srv/cv
-    file_server
-  }
-
-  # API
+:80 {
+  # Backend routes
   handle_path /api/* {
     reverse_proxy backend:8000
   }
-
-  # everything else -> frontend
-  handle {
-    reverse_proxy frontend:3000
+  handle_path /qrs/* {
+    reverse_proxy backend:8000
   }
+
+  # Everything else => Next.js frontend
+  reverse_proxy frontend:3000
+}
+
+# CV site — HTTP only at origin (Cloudflare provides TLS to the world)
+http://cv.blainweb.com {
+  root * /srv/cv
+  file_server
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "80:80"     # later you can switch to "127.0.0.1:80:80" after the tunnel works
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./cv-site:/srv/cv:ro        # <-- serve your CV files here
     depends_on:
       - frontend
       - backend


### PR DESCRIPTION
- Caddyfile: add /qrs/* -> backend:8000 and cv.blainweb.com static site
- Caddyfile: keep origin HTTP-only behind Cloudflare Tunnel (auto_https off)
- deploy.yml: add optional step to `caddy reload` after compose up

Enables hosting CV at https://cv.blainweb.com and fixes QR image URLs via /qrs/*.