### PR TITLE
- Add cert-manager ClusterIssuer (Let’s Encrypt) at

### DIFF
--- a/k8s/cert-manager/clusterissuer-letsencrypt.yaml
+++ b/k8s/cert-manager/clusterissuer-letsencrypt.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt
+spec:
+  acme:
+    email: blainmccormick@gmail.com         
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-key
+    solvers:
+    - http01:
+        ingress:
+          class: traefik

--- a/k8s/qr-ingress.yaml
+++ b/k8s/qr-ingress.yaml
@@ -9,8 +9,13 @@ metadata:
   annotations:
     traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
     traefik.ingress.kubernetes.io/router.middlewares: qr-qr-api-strip@kubernetescrd
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   ingressClassName: traefik
+  tls:
+    - hosts:
+        - qr.blainweb.com
+      secretName: qr-blainweb-tls
   rules:
     - host: qr.blainweb.com
       http:
@@ -21,7 +26,7 @@ spec:
               service:
                 name: qr-backend
                 port:
-                  number: 8000   # (use 80 here if your Service exposes 80)
+                  number: 8000
 ---
 # Ingress for everything else (no strip)
 apiVersion: networking.k8s.io/v1
@@ -31,8 +36,14 @@ metadata:
   namespace: qr
   labels:
     app: qr
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
 spec:
   ingressClassName: traefik
+  tls:
+    - hosts:
+        - qr.blainweb.com
+      secretName: qr-blainweb-tls
   rules:
     - host: qr.blainweb.com
       http:

--- a/k8s/storage/qrs-pvc.yaml
+++ b/k8s/storage/qrs-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: qrs-pvc
+  namespace: qr
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
  k8s/cert-manager/clusterissuer-letsencrypt.yaml
- Add PVC for backend image storage at k8s/storage/qrs-pvc.yaml
- Update k8s/qr-ingress.yaml:
  - annotate with cert-manager.io/cluster-issuer: letsencrypt
  - add tls: block using secret qr-blainweb-tls for qr.blainweb.com
  - add tls: block using secret qr-blainweb-tls for qr.blainweb.com