### PR TITLE
feat(backup): add Velero (Backblaze B2) + daily scheduled backups; wi…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,6 +138,46 @@ jobs:
       - name: Ensure Grafana admin password
         run: docker exec grafana grafana-cli admin reset-admin-password '${{ secrets.GRAFANA_ADMIN_PASSWORD }}' || true
 
+              # -------- Velero (Backblaze B2) --------
+      - name: Ensure Velero namespace + credentials Secret
+        run: |
+          set -e
+          kubectl apply -f infra/velero/namespace.yaml
+
+          # Create/patch secret with S3-compatible credentials in Velero's expected format
+          kubectl -n velero apply -f - <<'EOF'
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: velero-credentials
+          type: Opaque
+          stringData:
+            cloud: |
+              [default]
+              aws_access_key_id = ${B2_KEY_ID}
+              aws_secret_access_key = ${B2_APP_KEY}
+          EOF
+        env:
+          B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
+          B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
+
+      - name: Install/upgrade Velero via HelmChart (k3s Helm controller)
+        run: |
+          set -e
+          kubectl apply -f infra/velero/helmchart.yaml
+          # wait for the velero deployment to be created, then ready
+          for i in $(seq 1 30); do
+            kubectl -n velero get deploy/velero >/dev/null 2>&1 && break
+            sleep 2
+          done
+          kubectl -n velero rollout status deploy/velero --timeout=180s || (kubectl -n velero get pods; exit 1)
+
+      - name: Apply Velero backup schedule
+        run: |
+          set -e
+          kubectl apply -f infra/velero/schedule-daily.yaml
+      # -------- end Velero --------
+
       # -------- NEW: wait for cert-manager, apply infra, wait for MetalLB, verify Traefik LB IP --------
       - name: Wait for cert-manager to be Available
         run: |

--- a/infra/velero/helmchart.yaml
+++ b/infra/velero/helmchart.yaml
@@ -1,0 +1,31 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: velero
+  namespace: kube-system
+spec:
+  chart: velero
+  repo: https://vmware-tanzu.github.io/helm-charts
+  targetNamespace: velero
+  valuesContent: |
+    initContainers:
+      - name: velero-plugin-for-aws
+        image: velero/velero-plugin-for-aws:v1.9.0
+        volumeMounts:
+          - name: plugins
+            mountPath: /target
+
+    credentials:
+      useSecret: true
+      existingSecret: velero-credentials
+      existingSecretKey: cloud
+
+    configuration:
+      provider: aws
+      backupStorageLocation:
+        name: default
+        bucket: velero-blain-backups                  
+        config:
+          region: eu-central-003                        
+          s3Url: https://s3.eu-central-003.backblazeb2.com
+          s3ForcePathStyle: true

--- a/infra/velero/namespace.yaml
+++ b/infra/velero/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: velero

--- a/infra/velero/schedule-daily.yaml
+++ b/infra/velero/schedule-daily.yaml
@@ -1,0 +1,12 @@
+apiVersion: velero.io/v1
+kind: Schedule
+metadata:
+  name: daily-backup
+  namespace: velero
+spec:
+  schedule: "0 3 * * *"         
+  template:
+    ttl: 168h                    
+    includedNamespaces:
+      - qr
+      - kube-system


### PR DESCRIPTION
…re into deploy

- infra/velero/helmchart.yaml: install Velero via k3s HelmChart
  - provider: aws (S3-compatible)
  - bucket: velero-blain-backups (B2)
  - region: eu-central-003
  - s3Url: https://s3.eu-central-003.backblazeb2.com
  - s3ForcePathStyle: true
  - aws plugin init container

- infra/velero/namespace.yaml: create `velero` namespace
- infra/velero/schedule-daily.yaml: daily backup schedule (3d retention)

- .github/workflows/deploy.yml:
  - create/patch `velero-credentials` Secret from Actions secrets (B2_KEY_ID/B2_APP_KEY)
  - apply HelmChart for Velero and wait for rollout
  - apply backup Schedule
  - keep existing MetalLB/Traefik/ClusterIssuer steps intact

Why:
- automated cluster & PVC backups to offsite storage
- easy disaster recovery; low-cost B2 backend

Secrets required:
- `B2_KEY_ID`, `B2_APP_KEY`

Verification (after deploy):
- `kubectl -n velero get deploy,po,backupstoragelocations,schedules`