### PR TITLE
ci(velero): fail-soft when B2 caps hit + skip restore test safely

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,14 +169,14 @@ jobs:
           B2_KEY_ID: ${{ secrets.B2_KEY_ID }}
           B2_APP_KEY: ${{ secrets.B2_APP_KEY }}
 
-      - name: Install/upgrade Velero via HelmChart (fail-fast)
+      - name: Install/upgrade Velero via HelmChart (fail-soft on B2 caps)
         shell: bash
         run: |
           set -euo pipefail
           cd ~/apps/devops-qr
           kubectl apply -f infra/velero/helmchart.yaml
 
-          # Wait up to ~2 minutes for the velero Deployment to show up
+          # Wait for the velero Deployment to appear
           echo "⏳ Waiting for velero Deployment to exist…"
           for i in {1..60}; do
             kubectl -n velero get deploy/velero >/dev/null 2>&1 && break || true
@@ -195,15 +195,21 @@ jobs:
           echo "⏳ Waiting for velero rollout…"
           kubectl -n velero rollout status deploy/velero --timeout=180s
 
-          # Node agent (optional) presence is informational
+          # Node agent info
           kubectl -n velero get ds/node-agent -o wide || true
 
-          # Require BackupStorageLocation to become Available
+          # Wait for BSL to become Available. If Backblaze caps are hit, pass the step and mark SKIP.
           echo "⏳ Waiting for BackupStorageLocation=Available…"
           for i in {1..90}; do
             PHASE=$(kubectl -n velero get backupstoragelocation default -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-            echo "BSL phase: ${PHASE:-<none>}"
+            MSG=$(kubectl -n velero get backupstoragelocation default -o jsonpath='{.status.message}' 2>/dev/null || echo "")
+            echo "BSL phase: ${PHASE:-<none>} ${MSG:+| $MSG}"
             [[ "$PHASE" == "Available" ]] && break
+            if [[ "$MSG" == *"Transaction cap exceeded"* ]]; then
+              echo "⚠️  Backblaze B2 transaction cap exceeded; continuing deploy and skipping smoke test."
+              echo "SKIP_VELERO_SMOKE=1" >> "$GITHUB_ENV"
+              exit 0
+            fi
             sleep 2
           done
 
@@ -230,10 +236,10 @@ jobs:
           kubectl -n velero describe schedule | sed -n '1,120p'
 
       - name: Create an on-demand Velero backup (smoke test)
+        if: env.SKIP_VELERO_SMOKE != '1'
         shell: bash
         run: |
           set -euo pipefail
-          # Only run if BSL is Available
           PHASE=$(kubectl -n velero get backupstoragelocation default -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
           if [[ "$PHASE" != "Available" ]]; then
             echo "❌ Skipping smoke backup because BSL is not Available ($PHASE)"
@@ -258,6 +264,7 @@ jobs:
           kubectl -n velero get backups
 
       - name: Wait for backup to complete
+        if: env.SKIP_VELERO_SMOKE != '1'
         shell: bash
         run: |
           set -euo pipefail

--- a/infra/velero/helmchart.yaml
+++ b/infra/velero/helmchart.yaml
@@ -28,9 +28,10 @@ spec:
           provider: aws
           bucket: velero-blain-backups
           accessMode: ReadWrite
-          credential:               
+          credential:
             name: velero-credentials
             key: cloud
+          validationFrequency: 1h   # <— NEW: validate less often to avoid B2 caps
           config:
             region: eu-central-003
             s3Url: https://s3.eu-central-003.backblazeb2.com

--- a/scripts/velero-restore-test.sh
+++ b/scripts/velero-restore-test.sh
@@ -18,6 +18,19 @@ echo "Restore   : $R"
 echo "Label     : $LABEL_SELECTOR"
 echo
 
+# --- Preflight: ensure BSL usable; skip if Backblaze caps are exceeded ---
+BSL_PHASE=$(kubectl -n velero get backupstoragelocation default -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+BSL_MSG=$(kubectl -n velero get backupstoragelocation default -o jsonpath='{.status.message}' 2>/dev/null || echo "")
+if [[ "$BSL_PHASE" != "Available" ]]; then
+  if [[ "$BSL_MSG" == *"Transaction cap exceeded"* ]]; then
+    echo "⚠️  Skipping restore test: Backblaze B2 transaction cap exceeded."
+    exit 0
+  fi
+  echo "❌ BSL not Available ($BSL_PHASE). Details:"
+  kubectl -n velero describe backupstoragelocation default || true
+  exit 1
+fi
+
 # 1) Create a test namespace and a simple object to verify later
 echo "--> Create test namespace + object"
 kubectl create ns "$NS"


### PR DESCRIPTION
deploy.yml

Treat Backblaze “Transaction cap exceeded” as non-fatal: print warning, set SKIP_VELERO_SMOKE=1, continue deploy.

Guard smoke backup + wait steps with if: env.SKIP_VELERO_SMOKE != '1'.

Keep hard failures for real install/rollout/BSL misconfig cases; improved diagnostics.

scripts/velero-restore-test.sh

Add preflight check of BSL (default); skip test when message contains “Transaction cap exceeded”.

Still fail fast for other non-Available states and for backup/restore failures.