### PR TITLE
Increase Argo CD server probe delays for Raspberry Pi

### DIFF
--- a/infra/argocd/helmchart.yaml
+++ b/infra/argocd/helmchart.yaml
@@ -16,6 +16,17 @@ spec:
       replicas: 1
 
     server:
+      # Give the Pi enough time to start Argo CD before probes fire.
+      # Default initialDelaySeconds=10 is too short for ARM64 — the server
+      # gets killed by its own liveness probe before it finishes starting.
+      livenessProbe:
+        initialDelaySeconds: 90
+        periodSeconds: 10
+        failureThreshold: 5
+      readinessProbe:
+        initialDelaySeconds: 60
+        periodSeconds: 10
+        failureThreshold: 5
       # ClusterIP; Traefik Ingress will front it
       service:
         type: ClusterIP


### PR DESCRIPTION
The argocd-server was stuck in CrashLoopBackOff (23 restarts, exit code 143/SIGTERM) because the default liveness probe fires after only 10s and kills the container after 3 failures (40s total). On ARM64/Pi, Argo CD takes longer than that to start, so it was being killed before it ever became healthy.

Increased initialDelaySeconds: 10 -> 90 for liveness and 60 for readiness, and bumped failureThreshold to 5. This gives the server ~90s to start before any probe can kill it.