### PR TITLE
Replace qr-env secret refs with inline env vars in qr-backend

### DIFF
--- a/k8s/qr-backend.yaml
+++ b/k8s/qr-backend.yaml
@@ -22,15 +22,9 @@ spec:
             - containerPort: 8000
           env:
             - name: FRONTEND_URL
-              valueFrom:
-                secretKeyRef:
-                  name: qr-env
-                  key: FRONTEND_URL
+              value: "https://qr.blainweb.com"
             - name: QR_CODE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: qr-env
-                  key: QR_CODE_URL
+              value: "https://qr.blainweb.com"
             - name: LOCAL_STORAGE_DIR
               value: /data/qrs
           livenessProbe:


### PR DESCRIPTION
FRONTEND_URL and QR_CODE_URL are non-sensitive URLs so there is no reason to store them in a Secret. Inlining them removes the manual secret creation dependency that caused backend pods to fail with CreateContainerConfigError after a cluster wipe.