### PR TITLE
Add pod diagnostics on health-wait failure; drop imagePullPolicy: Always

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -247,6 +247,16 @@ jobs:
           done
           echo "Argo CD app didn't reach Healthy+Synced in time"
           kubectl -n argocd get application qr-app -o yaml | sed -n '1,200p' || true
+          echo "=== Pod states ==="
+          kubectl -n qr get pods -o wide || true
+          echo "=== PVC status ==="
+          kubectl -n qr get pvc || true
+          echo "=== Pod events / describe ==="
+          kubectl -n qr describe pods || true
+          echo "=== Backend logs (last 80 lines) ==="
+          kubectl -n qr logs deploy/qr-backend --tail=80 --all-containers || true
+          echo "=== Frontend logs (last 40 lines) ==="
+          kubectl -n qr logs deploy/qr-frontend --tail=40 --all-containers || true
           exit 1
 
       # --- keep provisioning dirs clean on every deploy ---

--- a/k8s/qr-backend.yaml
+++ b/k8s/qr-backend.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: qr-backend
           image: ghcr.io/blainmac333/qr-backend:f0373934d0362b82060e5ddc39ae93233ae7fe79
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
           env:

--- a/k8s/qr-backend.yaml
+++ b/k8s/qr-backend.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: qr-backend
-          image: ghcr.io/blainmac333/qr-backend:f0373934d0362b82060e5ddc39ae93233ae7fe79
+          image: ghcr.io/blainmac333/qr-backend:33b111267f8c24879c9b4856d0c8d9ca297ba61e
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000


### PR DESCRIPTION
The health wait step was timing out with no information about why pods weren't becoming ready. Add kubectl describe/logs/pvc output to the failure path so the next run exposes the actual root cause.

Also switch qr-backend from imagePullPolicy: Always to IfNotPresent — images are pinned to an immutable commit SHA so Always just adds an unnecessary registry roundtrip on every pod restart on the Pi.