### PR TITLE
Ensure velero namespace exists before applying metrics Service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -326,6 +326,7 @@ jobs:
         run: |
           set -e
           cd ~/apps/devops-qr
+          kubectl get ns velero >/dev/null 2>&1 || kubectl create ns velero
           # Apply the Services from the correct path
           kubectl -n velero apply -f infra/velero/metrics-service.yaml
 


### PR DESCRIPTION
The 'Apply Velero metrics Service' step runs before the 'Ensure Velero namespace + credentials Secret' step that creates the velero namespace, causing kubectl apply to fail with 'namespaces velero not found'.

Add an idempotent namespace creation guard so the step is self-contained regardless of pipeline ordering.