### PR TITLE
Add cert-manager HelmChart install step before wait step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -585,12 +585,29 @@ jobs:
       # -------- end Velero --------
 
       # -------- NEW: wait for cert-manager, apply infra, wait for MetalLB, verify Traefik LB IP --------
+      - name: Install cert-manager via HelmChart
+        run: |
+          set -e
+          cd ~/apps/devops-qr
+          kubectl apply -f infra/cert-manager/helmchart.yaml
+
+          # Wait up to 5 min for the Helm controller to create the cert-manager deployments
+          echo "Waiting for cert-manager deployments to appear..."
+          for i in {1..60}; do
+            CNT=$(kubectl -n cert-manager get deploy --no-headers 2>/dev/null | wc -l | xargs)
+            if [[ "${CNT:-0}" -ge 3 ]]; then
+              echo "Found $CNT cert-manager deployments."
+              break
+            fi
+            sleep 5
+          done
+
       - name: Wait for cert-manager to be Available
         run: |
           set -e
-          kubectl -n cert-manager rollout status deploy/cert-manager --timeout=120s
-          kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=120s
-          kubectl -n cert-manager rollout status deploy/cert-manager-cainjector --timeout=120s
+          kubectl -n cert-manager rollout status deploy/cert-manager --timeout=300s
+          kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=300s
+          kubectl -n cert-manager rollout status deploy/cert-manager-cainjector --timeout=300s
 
       - name: Apply cluster infra (MetalLB, Traefik, ClusterIssuer)
         run: |

--- a/infra/cert-manager/helmchart.yaml
+++ b/infra/cert-manager/helmchart.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: cert-manager
+  namespace: kube-system
+spec:
+  chart: cert-manager
+  repo: https://charts.jetstack.io
+  version: v1.16.2
+  targetNamespace: cert-manager
+  createNamespace: true
+  valuesContent: |
+    crds:
+      enabled: true


### PR DESCRIPTION
The pipeline was waiting for cert-manager deployments that were never installed — only the ClusterIssuer was applied later, not cert-manager itself. This caused 'namespaces cert-manager not found' immediately.

Add infra/cert-manager/helmchart.yaml using the same k3s HelmChart CRD pattern as ArgoCD and Velero (chart v1.16.2, CRDs enabled). Add an install step in the pipeline before the wait, with a 5-minute poll for deployments to appear. Also increase rollout status timeout from 120s to 300s since a fresh install on the Pi needs more time.