### PR TITLE
Add MetalLB HelmChart install step before applying pool config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -609,6 +609,24 @@ jobs:
           kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=300s
           kubectl -n cert-manager rollout status deploy/cert-manager-cainjector --timeout=300s
 
+      - name: Install MetalLB via HelmChart
+        run: |
+          set -e
+          cd ~/apps/devops-qr
+          kubectl apply -f infra/metallb/helmchart.yaml
+
+          # Wait for MetalLB CRDs to exist before we apply IPAddressPool / L2Advertisement
+          echo "Waiting for MetalLB CRDs..."
+          for i in {1..60}; do
+            kubectl get crd ipaddresspools.metallb.io >/dev/null 2>&1 && \
+            kubectl get crd l2advertisements.metallb.io >/dev/null 2>&1 && \
+            echo "MetalLB CRDs ready." && break || true
+            sleep 5
+          done
+
+          # Confirm CRDs actually appeared
+          kubectl get crd ipaddresspools.metallb.io l2advertisements.metallb.io
+
       - name: Apply cluster infra (MetalLB, Traefik, ClusterIssuer)
         run: |
           set -e

--- a/infra/metallb/helmchart.yaml
+++ b/infra/metallb/helmchart.yaml
@@ -1,0 +1,11 @@
+apiVersion: helm.cattle.io/v1
+kind: HelmChart
+metadata:
+  name: metallb
+  namespace: kube-system
+spec:
+  chart: metallb
+  repo: https://metallb.github.io/metallb
+  version: 0.14.9
+  targetNamespace: metallb-system
+  createNamespace: true


### PR DESCRIPTION
The pipeline applied IPAddressPool and L2Advertisement (metallb.io/v1beta1) before MetalLB was installed, so the CRDs didn't exist yet and kubectl apply failed with 'no matches for kind IPAddressPool'.

Add infra/metallb/helmchart.yaml (v0.14.9, same k3s HelmChart pattern as ArgoCD/Velero/cert-manager) and a pipeline step that applies it then waits for both CRDs to appear before the Apply cluster infra step runs.