### PR TITLE
Wait for MetalLB controller rollout before applying pool config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -627,6 +627,12 @@ jobs:
           # Confirm CRDs actually appeared
           kubectl get crd ipaddresspools.metallb.io l2advertisements.metallb.io
 
+          # Wait for the MetalLB controller (which runs the admission webhook) to be
+          # ready. Without this, applying IPAddressPool / L2Advertisement fails with
+          # "no endpoints available for service metallb-webhook-service".
+          echo "Waiting for MetalLB controller rollout..."
+          kubectl -n metallb-system rollout status deploy/controller --timeout=300s
+
       - name: Apply cluster infra (MetalLB, Traefik, ClusterIssuer)
         run: |
           set -e


### PR DESCRIPTION
After the MetalLB CRDs appear the controller pod (which hosts the admission webhook) still needs time to start. Applying IPAddressPool or L2Advertisement before it's ready fails with 'no endpoints available for service metallb-webhook-service'.

Add a rollout status wait on deploy/controller in metallb-system after the CRD check and before the Apply cluster infra step runs.