### PR TITLE
feat: enable HTTPS on qr.blainweb.com via Cloudflare Origin Certificate

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,7 +2,9 @@
   auto_https off
 }
 
-http://qr.blainweb.com {
+qr.blainweb.com {
+  tls /etc/caddy/certs/origin.pem /etc/caddy/certs/origin.key
+
   # ACME challenge must hit Traefik LB (MetalLB IP)
   handle /.well-known/acme-challenge/* {
     reverse_proxy 192.168.1.220:80 {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,13 @@ services:
     container_name: qr-proxy
     ports:
       - "80:80"
+      - "443:443"
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - ./cv-site:/srv/cv:ro
+      - /etc/caddy/certs:/etc/caddy/certs:ro
     restart: unless-stopped
 
   # ---------- Monitoring stack ----------


### PR DESCRIPTION
- Switch qr.blainweb.com from http:// to HTTPS with explicit TLS using Cloudflare Origin Certificate stored at /etc/caddy/certs/
- Expose port 443 in docker-compose and mount /etc/caddy/certs into the qr-proxy container