### PR TITLE
fix: restore HTTP for qr.blainweb.com alongside HTTPS

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -2,9 +2,7 @@
   auto_https off
 }
 
-qr.blainweb.com {
-  tls /etc/caddy/certs/origin.pem /etc/caddy/certs/origin.key
-
+(qr_routes) {
   # ACME challenge must hit Traefik LB (MetalLB IP)
   handle /.well-known/acme-challenge/* {
     reverse_proxy 192.168.1.220:80 {
@@ -25,6 +23,17 @@ qr.blainweb.com {
       header_up Host {host}
     }
   }
+}
+
+# HTTP — used by CI smoke test (localhost:80) and ACME challenges
+http://qr.blainweb.com {
+  import qr_routes
+}
+
+# HTTPS — Cloudflare origin (Full SSL mode) connects here
+qr.blainweb.com {
+  tls /etc/caddy/certs/origin.pem /etc/caddy/certs/origin.key
+  import qr_routes
 }
 
 # CV site — HTTP only at origin


### PR DESCRIPTION
## Summary
- Previous PR broke the CI smoke test — switching `http://qr.blainweb.com` to `qr.blainweb.com` with TLS made Caddy HTTPS-only, so `curl http://localhost/api/generate-qr` got no matching site block and returned empty
- Fix: use a Caddy snippet `(qr_routes)` shared by both an `http://qr.blainweb.com` block (for CI + internal) and a `qr.blainweb.com` TLS block (for Cloudflare Full SSL)

## Test plan
- [ ] Merge to trigger CI/CD
- [ ] Smoke test step 1 (health via HTTP) passes
- [ ] Smoke test step 2 (generate-qr via HTTP) passes
- [ ] `https://qr.blainweb.com/api/health` works from external network

🤖 Generated with [Claude Code](https://claude.com/claude-code)