### PR TITLE
fix: route argocd.blainweb.com to Traefik MetalLB IP

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -58,7 +58,7 @@ http://argocd.blainweb.com {
 
   # Everything else proxy to Traefik
   handle {
-    reverse_proxy 127.0.0.1:80 {
+    reverse_proxy 192.168.1.220:80 {
       header_up Host {host}
     }
   }


### PR DESCRIPTION
## Summary
- `127.0.0.1` inside the Caddy Docker container resolves to Caddy's own loopback, causing ArgoCD traffic to loop back to Caddy instead of reaching Traefik
- Fix points the `handle` block to `192.168.1.220:80` (Traefik MetalLB IP), matching what the ACME challenge block already uses

## Test plan
- [ ] Merge and wait for deploy to Pi
- [ ] Visit https://argocd.blainweb.com — should load ArgoCD UI instead of blank page

🤖 Generated with [Claude Code](https://claude.com/claude-code)