### PR TITLE
fix: flush argocd reverse proxy to fix blank page

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -60,6 +60,7 @@ http://argocd.blainweb.com {
   handle {
     reverse_proxy 192.168.1.220:80 {
       header_up Host {host}
+      flush_interval -1
     }
   }
 }


### PR DESCRIPTION
## Summary
- Caddy was buffering Traefik's chunked response body and never forwarding it to the client, resulting in a 200 with empty body in the browser
- `flush_interval -1` forces Caddy to stream the response immediately instead of buffering

## Test plan
- [ ] Merge and wait for deploy
- [ ] Visit https://argocd.blainweb.com — should load the ArgoCD login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)