### PR TITLE
fix: consolidate GHCR pull secret setup to prevent ImagePullBackOff

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,17 +85,31 @@ jobs:
           kubectl get nodes -o wide || true
 
       - name: Ensure GHCR pull secret exists
+        shell: bash
+        env:
+          GHCR_USER: ${{ github.repository_owner }}
+          GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
         run: |
+          set -euo pipefail
+          if [ -z "${GHCR_READ_TOKEN:-}" ]; then
+            echo "GHCR_READ_TOKEN not set; skipping pull-secret setup."
+            exit 0
+          fi
+
           kubectl get ns qr >/dev/null 2>&1 || kubectl create ns qr
 
-          kubectl -n qr create secret docker-registry ghcr-pull \
+          kubectl -n qr create secret docker-registry ghcr-creds \
             --docker-server=ghcr.io \
-            --docker-username="${{ secrets.GHCR_USERNAME }}" \
-            --docker-password="${{ secrets.GHCR_PULL_TOKEN }}" \
+            --docker-username="${GHCR_USER}" \
+            --docker-password="${GHCR_READ_TOKEN}" \
+            --docker-email=none@example.com \
             --dry-run=client -o yaml | kubectl apply -f -
 
           kubectl -n qr patch serviceaccount default \
-            -p '{"imagePullSecrets":[{"name":"ghcr-pull"}]}' || true
+            --type merge \
+            -p '{"imagePullSecrets":[{"name":"ghcr-creds"}]}' >/dev/null || true
+
+          echo "✅ Ensured ghcr-creds in namespace 'qr'"
       
       - name: Update k8s image tags to this commit and push (GitOps)
         if: github.ref == 'refs/heads/master'
@@ -735,33 +749,6 @@ jobs:
           echo "⚠️ NodePort not reachable yet, continuing (Prometheus will retry)"
 
       # -------- END NEW --------
-      - name: Ensure GHCR pull secret (qr namespace)
-        shell: bash
-        env:
-          GHCR_USER: ${{ github.repository_owner }}
-          GHCR_READ_TOKEN: ${{ secrets.GHCR_READ_TOKEN }}
-        run: |
-          set -euo pipefail
-          if [ -z "${GHCR_READ_TOKEN:-}" ]; then
-            echo "GHCR_READ_TOKEN not set; skipping pull-secret setup."
-            exit 0
-          fi
-
-          NS=qr
-          kubectl get ns "$NS" >/dev/null 2>&1 || kubectl create ns "$NS"
-
-          kubectl -n "$NS" create secret docker-registry ghcr-creds \
-            --docker-server=ghcr.io \
-            --docker-username="${GHCR_USER}" \
-            --docker-password="${GHCR_READ_TOKEN}" \
-            --docker-email=none@example.com \
-            --dry-run=client -o yaml | kubectl apply -f -
-
-          kubectl -n "$NS" patch serviceaccount default \
-            --type merge \
-            -p '{"imagePullSecrets":[{"name":"ghcr-creds"}]}' >/dev/null || true
-
-          echo "✅ Ensured ghcr-creds in namespace '$NS'"
 
       # ---------- k3s: apply manifests & pin images to this commit ----------
       # - name: Apply k8s manifests


### PR DESCRIPTION
The deploy had two conflicting pull-secret steps. The early step created ghcr-pull using the now-unused GHCR_PULL_TOKEN secret, and a late step (after the rollout wait) overwrote the SA's imagePullSecrets with ghcr-creds. This meant the rollout ran with stale/invalid credentials, causing 403 on pull.

Consolidate into a single early step using GHCR_READ_TOKEN so the correct secret is in place before ArgoCD triggers the pod rollout. Remove the duplicate late step.