### PR TITLE
fix: serve argocd over HTTPS in Caddy and stop Traefik HTTP redirect

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -47,16 +47,32 @@ http://grafana.blainweb.com {
   reverse_proxy grafana:3000
 }
 
-# Argo CD UI via Traefik Ingress (HTTP origin; Traefik handles TLS)
+# Argo CD UI — HTTP (for internal/CI access)
 http://argocd.blainweb.com {
-  # Let’s Encrypt HTTP-01 challenge must reach Traefik (MetalLB IP)
   handle /.well-known/acme-challenge/* {
     reverse_proxy 192.168.1.220:80 {
       header_up Host {host}
     }
   }
 
-  # Everything else proxy to Traefik
+  handle {
+    reverse_proxy 192.168.1.220:80 {
+      header_up Host {host}
+      flush_interval -1
+    }
+  }
+}
+
+# Argo CD UI — HTTPS (Cloudflare origin connects here)
+argocd.blainweb.com {
+  tls /etc/caddy/certs/origin.pem /etc/caddy/certs/origin.key
+
+  handle /.well-known/acme-challenge/* {
+    reverse_proxy 192.168.1.220:80 {
+      header_up Host {host}
+    }
+  }
+
   handle {
     reverse_proxy 192.168.1.220:80 {
       header_up Host {host}

--- a/infra/argocd/helmchart.yaml
+++ b/infra/argocd/helmchart.yaml
@@ -35,13 +35,8 @@ spec:
         ingressClassName: traefik
         hosts:
           - argocd.blainweb.com
-        tls:
-          - secretName: argocd-tls
-            hosts:
-              - argocd.blainweb.com
         annotations:
-          kubernetes.io/tls-acme: "true"
-          cert-manager.io/cluster-issuer: "letsencrypt"   # <- change if your ClusterIssuer has a different name
+          traefik.ingress.kubernetes.io/router.entrypoints: web
       # Optional: let ArgoCD serve HTTPS directly behind Traefik
       extraArgs:
         - --insecure


### PR DESCRIPTION
Cloudflare connects to the origin on port 443 (Full SSL), but Caddy only had an HTTP block for argocd.blainweb.com, causing empty 200 responses.

Add an HTTPS block using the existing origin cert so Caddy properly handles Cloudflare's HTTPS connections and proxies them to Traefik.

Remove TLS from the ArgoCD Ingress and pin it to the web (HTTP) entrypoint so Traefik stops issuing 307 HTTP→HTTPS redirects, which were looping requests back through Cloudflare.