### PR TITLE
fix: replace direct GitOps push with PR-based flow

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1,14 +1,12 @@
-name: CI Pipeline
+name: Build and Test
 
 on:
   pull_request:
     branches:
       - master
   push:
-    branches:
+    branches-ignore:
       - master
-      - feature/api-setup
-      - feature/docker-files
 
 jobs:
   build-and-push:
@@ -16,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 
@@ -29,30 +27,27 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      # Docker setup for building and pushing images
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      # Build and push API image
       - name: Build and push API Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: ./api
           file: ./api/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-api:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}
 
-      # Build and push Frontend image
       - name: Build and push Frontend Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: ./front-end-nextjs
           file: ./front-end-nextjs/Dockerfile
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:latest
+          tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -111,56 +112,27 @@ jobs:
 
           echo "✅ Ensured ghcr-creds in namespace 'qr'"
       
-      - name: Update k8s image tags to this commit and push (GitOps)
-        if: github.ref == 'refs/heads/master'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pin image tags in k8s manifests
         run: |
           set -euo pipefail
           SHA="${GITHUB_SHA}"
+          sed -i -E "s@(ghcr\.io/.*/qr-backend:)([A-Za-z0-9._-]+|latest)@\1${SHA}@g" ./k8s/qr-backend.yaml
+          sed -i -E "s@(ghcr\.io/.*/qr-frontend:)([A-Za-z0-9._-]+|latest)@\1${SHA}@g" ./k8s/qr-frontend.yaml
 
-          B=./k8s/qr-backend.yaml
-          F=./k8s/qr-frontend.yaml
+      - name: Open GitOps PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "GitOps: pin images to ${{ github.sha }}"
+          branch: gitops/update-${{ github.sha }}
+          title: "GitOps: deploy ${{ github.sha }}"
+          body: |
+            Automated image tag update triggered by merge to master.
 
-          sed -i -E "s@(ghcr\.io/.*/qr-backend:)([A-Za-z0-9._-]+|latest)@\1${SHA}@g" "$B"
-          sed -i -E "s@(ghcr\.io/.*/qr-frontend:)([A-Za-z0-9._-]+|latest)@\1${SHA}@g" "$F"
-
-          git config --global user.email "ci@users.noreply.github.com"
-          git config --global user.name  "ci-bot"
-
-          git add "$B" "$F"
-
-          if git diff --cached --quiet; then
-            echo "No image tag changes to commit."
-            exit 0
-          fi
-
-          git commit -m "GitOps: pin images to ${SHA}"
-
-          # Push using explicit auth so it works on self-hosted, but handle non-fast-forward safely.
-          REMOTE="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
-
-          for attempt in 1 2 3 4 5; do
-            echo "Push attempt ${attempt}..."
-
-            # Ensure we're based on latest master before pushing (avoids non-fast-forward)
-            git fetch "$REMOTE" master
-
-            # Rebase our new commit on top of latest master
-            git rebase FETCH_HEAD
-
-            # Try push
-            if git push "$REMOTE" HEAD:master; then
-              echo "Push succeeded."
-              exit 0
-            fi
-
-            echo "Push failed (likely race). Retrying in 3s..."
-            sleep 3
-          done
-
-          echo "Push failed after 5 attempts."
-          exit 1
+            - `qr-backend:${{ github.sha }}`
+            - `qr-frontend:${{ github.sha }}`
+          base: master
+          labels: gitops
 
 
       - name: Sync repo files on Pi


### PR DESCRIPTION
Instead of pushing image-tag commits directly to master (which branch protection rules block), the deploy job now opens a PR via peter-evans/create-pull-request. ci-pipeline.yml is updated to only run on PRs and non-master branches, avoiding duplicate builds.