### PR TITLE
Add Terraform Cloudflare DNS management

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Plan
         id: plan
-        run: terraform plan -no-color
+        run: terraform plan -no-color -lock=false
         continue-on-error: true
 
       - name: Post plan to PR

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -17,7 +17,6 @@ jobs:
         working-directory: terraform
 
     env:
-      TF_TOKEN_app_terraform_io: ${{ secrets.TF_API_TOKEN }}
       TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
 
@@ -27,6 +26,7 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.9.0"
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Init
         run: terraform init

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,68 @@
+name: Terraform
+
+on:
+  push:
+    branches: [master]
+    paths: [terraform/**]
+  pull_request:
+    branches: [master]
+    paths: [terraform/**]
+
+jobs:
+  terraform:
+    name: ${{ github.event_name == 'push' && 'Apply' || 'Plan' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+
+    env:
+      TF_TOKEN_app_terraform_io: ${{ secrets.TF_API_TOKEN }}
+      TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.9.0"
+
+      - name: Init
+        run: terraform init
+
+      - name: Format check
+        run: terraform fmt -check
+
+      - name: Validate
+        run: terraform validate
+
+      - name: Plan
+        id: plan
+        run: terraform plan -no-color
+        continue-on-error: true
+
+      - name: Post plan to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `### Terraform Plan
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+            Plan status: ${{ steps.plan.outcome }}`;
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });
+
+      - name: Fail if plan failed
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Apply
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: terraform apply -auto-approve

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 grafana.env
+
+# Terraform
+terraform/.terraform/
+terraform/terraform.tfvars
+terraform/*.tfstate
+terraform/*.tfstate.backup
+terraform/.terraform.lock.hcl

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -1,0 +1,19 @@
+locals {
+  tunnel_cname = "${var.tunnel_id}.cfargotunnel.com"
+
+  subdomains = {
+    "qr"      = local.tunnel_cname
+    "cv"      = local.tunnel_cname
+    "grafana" = local.tunnel_cname
+  }
+}
+
+resource "cloudflare_record" "tunnel_subdomains" {
+  for_each = local.subdomains
+
+  zone_id = var.cloudflare_zone_id
+  name    = each.key
+  content = each.value
+  type    = "CNAME"
+  proxied = true
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+  }
+
+  cloud {
+    organization = "blainweb"
+
+    workspaces {
+      name = "cloudflare-dns"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,3 @@
+# Copy this to terraform.tfvars and fill in real values (never commit terraform.tfvars)
+cloudflare_api_token = "your-cloudflare-api-token"
+cloudflare_zone_id   = "your-zone-id-from-cloudflare-dashboard"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,16 @@
+variable "cloudflare_api_token" {
+  description = "Cloudflare API token with DNS edit permissions for blainweb.com"
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare Zone ID for blainweb.com"
+  type        = string
+}
+
+variable "tunnel_id" {
+  description = "Cloudflare Tunnel UUID for qr-pi tunnel"
+  type        = string
+  default     = "d9c6665a-3358-4740-8f62-61fcedbedf26"
+}


### PR DESCRIPTION
Defines CNAME records for qr/cv/grafana.blainweb.com pointing to the qr-pi Cloudflare Tunnel. State stored in Terraform Cloud. GitHub Actions runs plan on PRs and apply on merge to master.