### PR TITLE
Switch Terraform backend from HCP Terraform to Backblaze B2

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -17,6 +17,8 @@ jobs:
         working-directory: terraform
 
     env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.B2_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.B2_SECRET_ACCESS_KEY }}
       TF_VAR_cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       TF_VAR_cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID }}
 
@@ -26,7 +28,6 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.9.0"
-          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: Init
         run: terraform init
@@ -39,7 +40,7 @@ jobs:
 
       - name: Plan
         id: plan
-        run: terraform plan -no-color -lock=false
+        run: terraform plan -no-color
         continue-on-error: true
 
       - name: Post plan to PR
@@ -65,4 +66,4 @@ jobs:
 
       - name: Apply
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        run: terraform apply -auto-approve -lock=false
+        run: terraform apply -auto-approve

--- a/terraform/dns.tf
+++ b/terraform/dns.tf
@@ -12,9 +12,10 @@ locals {
 resource "cloudflare_record" "tunnel_subdomains" {
   for_each = local.subdomains
 
-  zone_id = var.cloudflare_zone_id
-  name    = each.key
-  content = each.value
-  type    = "CNAME"
-  proxied = true
+  zone_id         = var.cloudflare_zone_id
+  name            = each.key
+  content         = each.value
+  type            = "CNAME"
+  proxied         = true
+  allow_overwrite = true
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,12 +8,19 @@ terraform {
     }
   }
 
-  cloud {
-    organization = "blainweb"
+  backend "s3" {
+    bucket = "terraform-state-blain"
+    key    = "cloudflare-dns/terraform.tfstate"
+    region = "eu-central-003"
 
-    workspaces {
-      name = "cloudflare-dns"
+    endpoints = {
+      s3 = "https://s3.eu-central-003.backblazeb2.com"
     }
+
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    force_path_style            = true
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,11 +17,11 @@ terraform {
       s3 = "https://s3.eu-central-003.backblazeb2.com"
     }
 
-    skip_credentials_validation  = true
-    skip_metadata_api_check      = true
-    skip_region_validation       = true
-    skip_requesting_account_id   = true
-    use_path_style               = true
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    use_path_style              = true
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -17,10 +17,11 @@ terraform {
       s3 = "https://s3.eu-central-003.backblazeb2.com"
     }
 
-    skip_credentials_validation = true
-    skip_metadata_api_check     = true
-    skip_region_validation      = true
-    force_path_style            = true
+    skip_credentials_validation  = true
+    skip_metadata_api_check      = true
+    skip_region_validation       = true
+    skip_requesting_account_id   = true
+    use_path_style               = true
   }
 }
 


### PR DESCRIPTION
Replaces unreliable Terraform Cloud local-mode backend with B2 S3-compatible backend. Adds allow_overwrite=true to take ownership of existing DNS records.