### PR TITLE
Update cloudflared config example to match running config

### DIFF
--- a/cloudflared/config.example.yml
+++ b/cloudflared/config.example.yml
@@ -1,4 +1,4 @@
-﻿tunnel: qr-pi
+tunnel: qr-pi
 credentials-file: /etc/cloudflared/{{CREDENTIALS_JSON}}
 
 ingress:


### PR DESCRIPTION
Add cv and grafana ingress rules. All three subdomains route through Caddy on port 80 which handles internal Docker routing to each service.