### PR TITLE
Fix tunnel ID to use actual tunnel UUID not replica ID

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,5 +12,5 @@ variable "cloudflare_zone_id" {
 variable "tunnel_id" {
   description = "Cloudflare Tunnel UUID for qr-pi tunnel"
   type        = string
-  default     = "d9c6665a-3358-4740-8f62-61fcedbedf26"
+  default     = "3900c0d6-5fbd-4b25-b021-182baa1f5976"
 }


### PR DESCRIPTION
The replica ID d9c6665a was incorrectly used. The correct tunnel ID is 3900c0d6 from the credentials file on the Pi.