### PR TITLE
feat: wire kube-state-metrics into deploy pipeline and expose Prometh…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -718,7 +718,7 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          IP=$(hostname -I | awk '{print $1}')
+          IP=$(hostname -I | awk ‘{print $1}’)
           for i in {1..15}; do
             if curl -sf "http://$IP:31090/metrics" >/dev/null; then
               echo "✅ NodePort reachable"
@@ -729,6 +729,43 @@ jobs:
             sleep 2
           done
           echo "⚠️ NodePort not reachable yet, continuing (Prometheus will retry)"
+
+      # -------- Install/upgrade kube-state-metrics --------
+      - name: Install/upgrade kube-state-metrics
+        run: |
+          set -e
+          cd ~/apps/devops-qr
+          kubectl apply -f monitoring/kube-state-metrics.yaml
+          kubectl apply -f monitoring/kube-state-metrics-nodeport.yaml
+
+      - name: Wait for kube-state-metrics to be Ready
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "⏳ Waiting for kube-state-metrics Deployment to appear…"
+          for i in {1..60}; do
+            kubectl -n kube-system get deploy/kube-state-metrics >/dev/null 2>&1 && break || true
+            sleep 5
+          done
+          kubectl -n kube-system rollout status deploy/kube-state-metrics --timeout=180s
+          echo "✅ kube-state-metrics ready"
+
+      - name: Verify kube-state-metrics NodePort (best-effort)
+        shell: bash
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          IP=$(hostname -I | awk ‘{print $1}’)
+          for i in {1..15}; do
+            if curl -sf "http://$IP:30090/metrics" >/dev/null; then
+              echo "✅ kube-state-metrics NodePort reachable"
+              curl -sf "http://$IP:30090/metrics" | head -n 5 || true
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "⚠️ kube-state-metrics NodePort not reachable yet, continuing"
+      # -------- END kube-state-metrics --------
 
       # -------- END NEW --------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
       - --web.enable-lifecycle
+    ports:
+      - "9090:9090"
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prom-data:/prometheus


### PR DESCRIPTION
…eus port

Add kubectl apply steps for kube-state-metrics HelmChart and NodePort service in deploy.yml, following the same pattern as cAdvisor. Expose Prometheus on port 9090 in docker-compose for local UI access.