### PR TITLE
fix: route NodePort scrapes via host.docker.internal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - --web.enable-lifecycle
     ports:
       - "9090:9090"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prom-data:/prometheus

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -22,16 +22,16 @@ scrape_configs:
   - job_name: 'kube-state-metrics'
     scrape_interval: 30s
     static_configs:
-      - targets: ['192.168.1.106:30090']
+      - targets: ['host.docker.internal:30090']
 
   # cAdvisor on Kubernetes Nodes
   - job_name: 'cadvisor-k8s'
     scrape_interval: 30s
     static_configs:
-      - targets: ['192.168.1.106:31090']
+      - targets: ['host.docker.internal:31090']
 
   # Velero Metrics
   - job_name: 'velero'
     scrape_interval: 30s
     static_configs:
-      - targets: ['192.168.1.106:31085']
+      - targets: ['host.docker.internal:31085']


### PR DESCRIPTION
Prometheus in Docker can't reach the Pi host IP (192.168.1.106) via NodePorts. Add extra_hosts host-gateway to the prometheus service and replace hardcoded IPs in prometheus.yml with host.docker.internal, matching the pattern already used by the Caddy proxy.