### PR TITLE
fix: replace awk with cut to avoid unbound variable error in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -718,7 +718,7 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          IP=$(hostname -I | awk ‘{print $1}’)
+          IP=$(hostname -I | cut -d’ ‘ -f1)
           for i in {1..15}; do
             if curl -sf "http://$IP:31090/metrics" >/dev/null; then
               echo "✅ NodePort reachable"
@@ -755,7 +755,7 @@ jobs:
         continue-on-error: true
         run: |
           set -euo pipefail
-          IP=$(hostname -I | awk ‘{print $1}’)
+          IP=$(hostname -I | cut -d’ ‘ -f1)
           for i in {1..15}; do
             if curl -sf "http://$IP:30090/metrics" >/dev/null; then
               echo "✅ kube-state-metrics NodePort reachable"

--- a/monitoring/kube-state-metrics-nodeport.yaml
+++ b/monitoring/kube-state-metrics-nodeport.yaml
@@ -11,5 +11,5 @@ spec:
   ports:
     - name: http-metrics
       port: 8080
-      targetPort: http-metrics    
+      targetPort: 8080
       nodePort: 30090              


### PR DESCRIPTION
awk '{print $1}' triggers bash's -u flag on the self-hosted runner. Replaced with cut -d' ' -f1 in both best-effort NodePort check steps.