### PR TITLE
Fix Disk I/O panel: add nvme device support

### DIFF
--- a/monitoring/grafana-provisioning/dashboards/pi-overview.json
+++ b/monitoring/grafana-provisioning/dashboards/pi-overview.json
@@ -142,8 +142,8 @@
       "fieldConfig": { "defaults": { "unit": "Bps" } },
       "options": { "legend": { "showLegend": true, "placement": "bottom" } },
       "targets": [
-        { "expr": "sum by (device) (rate(node_disk_read_bytes_total{device=~\"sd.*|mmcblk.*\"}[5m]))", "legendFormat": "{{device}} read" },
-        { "expr": "sum by (device) (rate(node_disk_written_bytes_total{device=~\"sd.*|mmcblk.*\"}[5m]))", "legendFormat": "{{device}} write" }
+        { "expr": "sum by (device) (rate(node_disk_read_bytes_total{device=~\"sd.*|mmcblk.*|nvme.*\"}[5m]))", "legendFormat": "{{device}} read" },
+        { "expr": "sum by (device) (rate(node_disk_written_bytes_total{device=~\"sd.*|mmcblk.*|nvme.*\"}[5m]))", "legendFormat": "{{device}} write" }
       ],
       "datasource": { "type": "prometheus", "uid": "prometheus" }
     },


### PR DESCRIPTION
## Summary
- Pi uses NVMe storage (`nvme0n1`), not SD card or USB
- Previous device filter `sd.*|mmcblk.*` matched nothing, causing "No Data"
- Updated both read and write queries to include `nvme.*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)