### PR TITLE
Fix cadvisor-k8s Prometheus relabeling - root cause of all no-data panels

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -29,6 +29,15 @@ scrape_configs:
     scrape_interval: 30s
     static_configs:
       - targets: ['host.docker.internal:31090']
+        labels:
+          node: 'raspberrypi'
+    metric_relabel_configs:
+      - source_labels: [container_label_io_kubernetes_container_name]
+        target_label: container
+      - source_labels: [container_label_io_kubernetes_pod_name]
+        target_label: pod
+      - source_labels: [container_label_io_kubernetes_pod_namespace]
+        target_label: namespace
 
   # Velero Metrics
   - job_name: 'velero'


### PR DESCRIPTION
## Root cause

cAdvisor scrapes Kubernetes container metrics but exposes Kubernetes metadata as raw container runtime labels rather than standard Prometheus labels. Every dashboard query filtering on container/pod/namespace returned no data because those labels simply did not exist on the metrics.

## What was wrong

The cadvisor-k8s job metrics had labels like container_label_io_kubernetes_container_name, container_label_io_kubernetes_pod_name, container_label_io_kubernetes_pod_namespace instead of the expected container, pod, namespace labels. Queries like container_cpu_usage_seconds_total{container!=''} returned nothing.

## Fix

Added metric_relabel_configs to the cadvisor-k8s scrape job to copy the raw kubernetes container labels into the standard names. Also added a static node label since NodePort scraping cannot derive the node name from the instance address.

## Test plan
- [ ] Merge and wait for deploy
- [ ] Run container_cpu_usage_seconds_total{job='cadvisor-k8s', container!=''} in Explore - should now return data
- [ ] Open K8s dashboard - all previously empty panels should now show data

Generated with Claude Code