### PR TITLE
fix: restart Prometheus on deploy instead of broken hot-reload

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -361,8 +361,9 @@ jobs:
 
           PROM=$(docker ps --format '{{.Names}}' | grep -i prometheus | head -n1)
 
-          echo "→ Reload Prometheus config"
-          docker exec "$PROM" wget -qO- --post-data="" http://localhost:9090/-/reload >/dev/null 2>&1 || true
+          echo "→ Restart Prometheus to pick up new config (hot-reload fails after git replaces file inode)"
+          docker restart "$PROM"
+          sleep 10
 
           echo "---- container prometheus.yml grep ----"
           docker exec "$PROM" sh -lc "grep -En \"job_name:[[:space:]]*['\\\"]?velero['\\\"]?\" /etc/prometheus/prometheus.yml || echo '❌ velero job not found inside container'"


### PR DESCRIPTION
## Problem

The deploy pipeline was using Prometheus's HTTP hot-reload endpoint to pick up prometheus.yml changes. This silently fails when git pull replaces the file with a new inode — Docker bind mounts hold a reference to the old inode until the container restarts, so Prometheus keeps reading the old config even after a successful 200 OK reload response.

This is the same pattern already used for Grafana (docker restart grafana) which works correctly.

## Fix

Replace the hot-reload HTTP call with docker restart in the existing 'Ensure Prometheus picked up prometheus.yml' step. Prometheus restarts in ~5 seconds and reads the freshly mounted file with the correct inode.

## Test plan
- [ ] Merge and let the deploy pipeline run
- [ ] Check Prometheus UI Status > Configuration — metric_relabel_configs should appear under cadvisor-k8s
- [ ] Verify container_cpu_usage_seconds_total{job='cadvisor-k8s',container!=''} returns data in Grafana Explore
- [ ] Confirm K8s dashboard panels now show data

Generated with Claude Code