### PR TITLE
feat: add resource requests/limits to monitoring workloads

### DIFF
--- a/monitoring/cadvisor-daemonset.yaml
+++ b/monitoring/cadvisor-daemonset.yaml
@@ -22,6 +22,13 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "250m"
+              memory: "200Mi"
           args:
             - --housekeeping_interval=10s
             # IMPORTANT: k3s containerd socket:

--- a/monitoring/kube-state-metrics.yaml
+++ b/monitoring/kube-state-metrics.yaml
@@ -12,6 +12,14 @@ spec:
     selfMonitor:
       enabled: false
 
+    resources:
+      requests:
+        cpu: "10m"
+        memory: "32Mi"
+      limits:
+        cpu: "100m"
+        memory: "96Mi"
+
     service:
       annotations:
         prometheus.io/scrape: "true"


### PR DESCRIPTION
Adds CPU and memory requests/limits to cadvisor DaemonSet and kube-state-metrics HelmChart. Prevents either from OOM-killing other pods on the Pi, and makes Grafana CPU/memory % panels meaningful.