### PR TITLE
fix: show 0 instead of no-data on restart and Velero panels

### DIFF
--- a/monitoring/grafana-provisioning/dashboards/pi-overview.json
+++ b/monitoring/grafana-provisioning/dashboards/pi-overview.json
@@ -210,7 +210,7 @@
       ],
       "targets": [
         {
-          "expr": "sum by (pod, container) (increase(kube_pod_container_status_restarts_total{namespace=\"qr\"}[$__range]))",
+          "expr": "sum by (pod, container) (increase(kube_pod_container_status_restarts_total{namespace=\"qr\"}[$__range])) or vector(0)",
           "legendFormat": "{{pod}}/{{container}}"
         }
       ],
@@ -223,7 +223,7 @@
       "fieldConfig": { "defaults": { "unit": "none" } },
       "options": { "reduceOptions": { "calcs": ["lastNotNull"] } },
       "targets": [
-        { "expr": "increase(velero_backup_attempt_total[$__range])", "legendFormat": "attempts" }
+        { "expr": "increase(velero_backup_attempt_total[$__range]) or vector(0)", "legendFormat": "attempts" }
       ],
       "datasource": { "type": "prometheus", "uid": "prometheus" }
     }


### PR DESCRIPTION
Container Restarts and Velero backup panels use increase() over $__range which returns no data (not zero) when the counter is flat or the metric series has no samples in the window. Adding or vector(0) ensures the panels always render rather than going blank.