### PR TITLE
fix: tolerate cadvisor scrape gaps in container memory panels

### DIFF
--- a/monitoring/grafana-provisioning/dashboards/pi-overview.json
+++ b/monitoring/grafana-provisioning/dashboards/pi-overview.json
@@ -179,7 +179,7 @@
       "options": { "legend": { "showLegend": true, "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "expr": "sum by (container_label_io_kubernetes_pod_name, name)(container_memory_working_set_bytes{job=\"cadvisor-k8s\",image!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"}) / 1024 / 1024",
+          "expr": "sum by (container_label_io_kubernetes_pod_name, name)(last_over_time(container_memory_working_set_bytes{job=\"cadvisor-k8s\",image!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"}[5m])) / 1024 / 1024",
           "legendFormat": "{{container_label_io_kubernetes_pod_name}}/{{name}}"
         }
       ],
@@ -193,7 +193,7 @@
       "options": { "displayMode": "gradient" },
       "targets": [
         {
-          "expr": "topk(8,(max_over_time(sum by (container_label_io_kubernetes_pod_name, name)(container_memory_working_set_bytes{job=\"cadvisor-k8s\",image!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"})[$__range:1m])-min_over_time(sum by (container_label_io_kubernetes_pod_name, name)(container_memory_working_set_bytes{job=\"cadvisor-k8s\",image!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"})[$__range:1m])) / 1024 / 1024)",
+          "expr": "topk(8,(max_over_time(sum by (container_label_io_kubernetes_pod_name, name)(last_over_time(container_memory_working_set_bytes{job=\"cadvisor-k8s\",image!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"}[5m]))[$__range:1m])-min_over_time(sum by (container_label_io_kubernetes_pod_name, name)(last_over_time(container_memory_working_set_bytes{job=\"cadvisor-k8s\",image!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"}[5m]))[$__range:1m])) / 1024 / 1024)",
           "legendFormat": "{{container_label_io_kubernetes_pod_name}}/{{name}}"
         }
       ],


### PR DESCRIPTION
Wraps container_memory_working_set_bytes in last_over_time([5m]) for both the Container Memory and Top Memory Growers panels. cadvisor-k8s scrapes every 30s so a 5m window covers ~10 missed scrapes, enough to survive a pod restart without the panels going blank.