### PR TITLE
﻿fix: replace image filter with container filter on cadvisor-k8s panels

### DIFF
--- a/monitoring/grafana-provisioning/dashboards/pi-overview.json
+++ b/monitoring/grafana-provisioning/dashboards/pi-overview.json
@@ -179,7 +179,7 @@
       "options": { "legend": { "showLegend": true, "placement": "bottom" }, "tooltip": { "mode": "multi" } },
       "targets": [
         {
-          "expr": "sum by (container_label_io_kubernetes_pod_name, name)(last_over_time(container_memory_working_set_bytes{job=\"cadvisor-k8s\",image!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"}[5m])) / 1024 / 1024",
+          "expr": "sum by (container_label_io_kubernetes_pod_name, name)(last_over_time(container_memory_working_set_bytes{job=\"cadvisor-k8s\",container!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"}[5m])) / 1024 / 1024",
           "legendFormat": "{{container_label_io_kubernetes_pod_name}}/{{name}}"
         }
       ],
@@ -193,7 +193,7 @@
       "options": { "displayMode": "gradient" },
       "targets": [
         {
-          "expr": "topk(8,(max_over_time(sum by (container_label_io_kubernetes_pod_name, name)(last_over_time(container_memory_working_set_bytes{job=\"cadvisor-k8s\",image!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"}[5m]))[$__range:1m])-min_over_time(sum by (container_label_io_kubernetes_pod_name, name)(last_over_time(container_memory_working_set_bytes{job=\"cadvisor-k8s\",image!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"}[5m]))[$__range:1m])) / 1024 / 1024)",
+          "expr": "topk(8,(max_over_time(sum by (container_label_io_kubernetes_pod_name, name)(last_over_time(container_memory_working_set_bytes{job=\"cadvisor-k8s\",container!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"}[5m]))[$__range:1m])-min_over_time(sum by (container_label_io_kubernetes_pod_name, name)(last_over_time(container_memory_working_set_bytes{job=\"cadvisor-k8s\",container!=\"\",container_label_io_kubernetes_pod_namespace=\"qr\"}[5m]))[$__range:1m])) / 1024 / 1024)",
           "legendFormat": "{{container_label_io_kubernetes_pod_name}}/{{name}}"
         }
       ],


### PR DESCRIPTION
k3s containerd cAdvisor does not expose an image label so the filter was dropping all data. Switched to container which works with containerd.