### PR TITLE
﻿fix: increase cadvisor memory limit to 350Mi to prevent OOMKill

### DIFF
--- a/monitoring/cadvisor-daemonset.yaml
+++ b/monitoring/cadvisor-daemonset.yaml
@@ -25,10 +25,10 @@ spec:
           resources:
             requests:
               cpu: "50m"
-              memory: "64Mi"
+              memory: "128Mi"
             limits:
               cpu: "250m"
-              memory: "200Mi"
+              memory: "350Mi"
           args:
             - --housekeeping_interval=10s
             # IMPORTANT: k3s containerd socket:


### PR DESCRIPTION
The 200Mi limit was too tight. cadvisor is tracking 145+ container series across argocd, cert-manager, traefik, kube-system and the qr namespace which drives memory above 200Mi. Bumped limit to 350Mi and request to 128Mi to reflect actual baseline usage.