### PR TITLE
﻿fix: use PAT instead of GITHUB_TOKEN for GitOps PR creation and merge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,7 +124,7 @@ jobs:
         id: create-pr
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_PAT }}
           commit-message: "GitOps: pin images to ${{ github.sha }}"
           branch: gitops/update-${{ github.sha }}
           title: "GitOps: deploy ${{ github.sha }}"
@@ -140,7 +140,7 @@ jobs:
         if: steps.create-pr.outputs.pull-request-number != ''
         run: |
           curl -X PUT \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Authorization: token ${{ secrets.GH_PAT }}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.create-pr.outputs.pull-request-number }}/merge" \
             -d '{"merge_method":"merge"}'


### PR DESCRIPTION
GitHub blocks workflow triggers on PRs created by GITHUB_TOKEN to prevent recursive loops. Switching to GH_PAT (a personal access token) means GitHub treats the PR as a human action and runs CI automatically without requiring manual approval each time.