### PR TITLE
﻿fix: break GitOps deploy loop by skipping on gitops merge commits

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   build-and-push:
+    if: "!contains(github.event.head_commit.message, 'gitops/update-')"
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
When a GitOps PR is auto-merged its commit message contains gitops/update- which triggers a new deploy creating another GitOps PR and so on forever. Adding an if condition on build-and-push skips the entire workflow when the triggering push is a GitOps merge. The deploy job is also skipped automatically because it depends on build-and-push.