### PR TITLE
﻿fix: move GitOps PR creation to separate job after deploy completes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,38 +114,6 @@ jobs:
 
           echo "✅ Ensured ghcr-creds in namespace 'qr'"
       
-      - name: Pin image tags in k8s manifests
-        run: |
-          set -euo pipefail
-          SHA="${GITHUB_SHA}"
-          sed -i -E "s@(ghcr\.io/.*/qr-backend:)([A-Za-z0-9._-]+|latest)@\1${SHA}@g" ./k8s/qr-backend.yaml
-          sed -i -E "s@(ghcr\.io/.*/qr-frontend:)([A-Za-z0-9._-]+|latest)@\1${SHA}@g" ./k8s/qr-frontend.yaml
-
-      - name: Open GitOps PR
-        id: create-pr
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GH_PAT }}
-          commit-message: "GitOps: pin images to ${{ github.sha }}"
-          branch: gitops/update-${{ github.sha }}
-          title: "GitOps: deploy ${{ github.sha }}"
-          body: |
-            Automated image tag update triggered by merge to master.
-
-            - `qr-backend:${{ github.sha }}`
-            - `qr-frontend:${{ github.sha }}`
-          base: master
-          labels: gitops
-
-      - name: Merge GitOps PR
-        if: steps.create-pr.outputs.pull-request-number != ''
-        run: |
-          curl -X PUT \
-            -H "Authorization: token ${{ secrets.GH_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.create-pr.outputs.pull-request-number }}/merge" \
-            -d '{"merge_method":"merge"}'
-
       - name: Sync repo files on Pi
         run: |
           set -e
@@ -882,3 +850,44 @@ jobs:
             exit 1
           fi
           echo "Smoke test passed ✅"
+
+  gitops-update:
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Pin image tags in k8s manifests
+        run: |
+          set -euo pipefail
+          SHA="${GITHUB_SHA}"
+          sed -i -E "s@(ghcr\.io/.*/qr-backend:)([A-Za-z0-9._-]+|latest)@\1${SHA}@g" ./k8s/qr-backend.yaml
+          sed -i -E "s@(ghcr\.io/.*/qr-frontend:)([A-Za-z0-9._-]+|latest)@\1${SHA}@g" ./k8s/qr-frontend.yaml
+
+      - name: Open GitOps PR
+        id: create-pr
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GH_PAT }}
+          commit-message: "GitOps: pin images to ${{ github.sha }}"
+          branch: gitops/update-${{ github.sha }}
+          title: "GitOps: deploy ${{ github.sha }}"
+          body: |
+            Automated image tag update triggered by merge to master.
+
+            - `qr-backend:${{ github.sha }}`
+            - `qr-frontend:${{ github.sha }}`
+          base: master
+          labels: gitops
+
+      - name: Merge GitOps PR
+        if: steps.create-pr.outputs.pull-request-number != ''
+        run: |
+          curl -X PUT \
+            -H "Authorization: token ${{ secrets.GH_PAT }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.create-pr.outputs.pull-request-number }}/merge" \
+            -d '{"merge_method":"merge"}'


### PR DESCRIPTION
The GitOps PR was being created and merged mid-way through the deploy job. Its merge triggered a new workflow which entered the deploy-pi concurrency group and cancelled the still-running deploy before all steps finished.

Moving the GitOps PR steps into a dedicated gitops-update job that needs deploy ensures the full deployment completes before the PR is created. The triggered skipped-build then fires against an already-finished workflow.