### PR TITLE
﻿feat: replace GitOps PR with direct commit to master using skip ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -856,38 +856,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GH_PAT }}
+          ref: master
 
-      - name: Pin image tags in k8s manifests
+      - name: Pin image tags and push directly to master
         run: |
           set -euo pipefail
           SHA="${GITHUB_SHA}"
           sed -i -E "s@(ghcr\.io/.*/qr-backend:)([A-Za-z0-9._-]+|latest)@\1${SHA}@g" ./k8s/qr-backend.yaml
           sed -i -E "s@(ghcr\.io/.*/qr-frontend:)([A-Za-z0-9._-]+|latest)@\1${SHA}@g" ./k8s/qr-frontend.yaml
-
-      - name: Open GitOps PR
-        id: create-pr
-        uses: peter-evans/create-pull-request@v8
-        with:
-          token: ${{ secrets.GH_PAT }}
-          commit-message: "GitOps: pin images to ${{ github.sha }}"
-          branch: gitops/update-${{ github.sha }}
-          title: "GitOps: deploy ${{ github.sha }}"
-          body: |
-            Automated image tag update triggered by merge to master.
-
-            - `qr-backend:${{ github.sha }}`
-            - `qr-frontend:${{ github.sha }}`
-          base: master
-          labels: gitops
-
-      - name: Merge GitOps PR
-        if: steps.create-pr.outputs.pull-request-number != ''
-        run: |
-          curl -X PUT \
-            -H "Authorization: token ${{ secrets.GH_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/pulls/${{ steps.create-pr.outputs.pull-request-number }}/merge" \
-            -d '{"merge_method":"merge"}'
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add k8s/qr-backend.yaml k8s/qr-frontend.yaml
+          git diff --staged --quiet && echo "No image tag changes to commit." && exit 0
+          git commit -m "GitOps: pin images to ${SHA} [skip ci]"
+          git push origin master


### PR DESCRIPTION
Instead of opening and merging a PR to update image tags, gitops-update now commits directly to master with [skip ci] in the message. GitHub does not trigger any workflow on skip ci pushes so there is no second merge PR and no 1-second skipped run. Git still records the exact image SHA deployed so ArgoCD has an accurate source of truth.

Requires Blainmac333 added as a bypass actor in branch protection.