### PR TITLE
﻿fix: set dashboard default time range to last 1 hour

### DIFF
--- a/monitoring/grafana-provisioning/dashboards/pi-overview.json
+++ b/monitoring/grafana-provisioning/dashboards/pi-overview.json
@@ -243,6 +243,6 @@
       }
     ]
   },
-  "time": { "from": "now-6h", "to": "now" },
+  "time": { "from": "now-1h", "to": "now" },
   "annotations": { "list": [ { "builtIn": 1, "type": "dashboard", "name": "Annotations & Alerts", "hide": true } ] }
 }


### PR DESCRIPTION
The 6h default caused the dashboard to open on stale data after periods of inactivity making panels appear blank. 1h keeps the view current.