### PR TITLE
CI: add Trivy image scanning before Docker Hub push

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -49,6 +49,15 @@ jobs:
           load: true
           tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}
 
+      - name: Show API image vulnerabilities (informational)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}'
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
+          ignore-unfixed: true
+
       - name: Scan API image with Trivy
         id: scan-api
         uses: aquasecurity/trivy-action@v0.36.0

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -50,6 +50,7 @@ jobs:
           tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}
 
       - name: Scan API image with Trivy
+        id: scan-api
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}'
@@ -57,10 +58,11 @@ jobs:
           output: 'trivy-api.sarif'
           severity: 'CRITICAL'
           exit-code: '1'
+          ignore-unfixed: true
 
       - name: Upload API scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        if: always() && steps.scan-api.outcome != 'skipped'
         with:
           sarif_file: 'trivy-api.sarif'
           category: 'trivy-api'
@@ -79,6 +81,7 @@ jobs:
           tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}
 
       - name: Scan Frontend image with Trivy
+        id: scan-frontend
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}'
@@ -86,10 +89,11 @@ jobs:
           output: 'trivy-frontend.sarif'
           severity: 'CRITICAL'
           exit-code: '1'
+          ignore-unfixed: true
 
       - name: Upload Frontend scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: always()
+        if: always() && steps.scan-frontend.outcome != 'skipped'
         with:
           sarif_file: 'trivy-frontend.sarif'
           category: 'trivy-frontend'

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -49,24 +49,30 @@ jobs:
           load: true
           tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}
 
-      - name: Show API image vulnerabilities (informational)
+      # Gate: fails the build if a fixable CRITICAL CVE is present.
+      # Table format is used because sarif format triggers on all severities
+      # regardless of the severity filter, making exit-code unreliable there.
+      - name: Scan API image - gate
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}'
           format: 'table'
-          severity: 'CRITICAL,HIGH'
-          exit-code: '0'
+          severity: 'CRITICAL'
+          exit-code: '1'
           ignore-unfixed: true
 
-      - name: Scan API image with Trivy
+      # Report: uploads CRITICAL+HIGH findings to the GitHub Security tab.
+      # exit-code 0 so this never blocks the build on its own.
+      - name: Scan API image - report to Security tab
         id: scan-api
         uses: aquasecurity/trivy-action@v0.36.0
+        if: always()
         with:
           image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}'
           format: 'sarif'
           output: 'trivy-api.sarif'
-          severity: 'CRITICAL'
-          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
           ignore-unfixed: true
 
       - name: Upload API scan results to GitHub Security tab
@@ -89,15 +95,25 @@ jobs:
           load: true
           tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}
 
-      - name: Scan Frontend image with Trivy
+      - name: Scan Frontend image - gate
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}'
+          format: 'table'
+          severity: 'CRITICAL'
+          exit-code: '1'
+          ignore-unfixed: true
+
+      - name: Scan Frontend image - report to Security tab
         id: scan-frontend
         uses: aquasecurity/trivy-action@v0.36.0
+        if: always()
         with:
           image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}'
           format: 'sarif'
           output: 'trivy-frontend.sarif'
-          severity: 'CRITICAL'
-          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '0'
           ignore-unfixed: true
 
       - name: Upload Frontend scan results to GitHub Security tab

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -50,7 +50,7 @@ jobs:
           tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}
 
       - name: Scan API image with Trivy
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}'
           format: 'sarif'
@@ -79,7 +79,7 @@ jobs:
           tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}
 
       - name: Scan Frontend image with Trivy
-        uses: aquasecurity/trivy-action@0.30.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}'
           format: 'sarif'

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -8,6 +8,9 @@ on:
     branches-ignore:
       - master
 
+permissions:
+  security-events: write
+
 jobs:
   build-and-push:
     runs-on: ubuntu-22.04
@@ -36,18 +39,60 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push API Docker image
+      # --- API image: build → scan → push ---
+      - name: Build API Docker image
         uses: docker/build-push-action@v7
         with:
           context: ./api
           file: ./api/Dockerfile
-          push: true
+          push: false
+          load: true
           tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}
 
-      - name: Build and push Frontend Docker image
+      - name: Scan API image with Trivy
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-api.sarif'
+          severity: 'CRITICAL'
+          exit-code: '1'
+
+      - name: Upload API scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-api.sarif'
+          category: 'trivy-api'
+
+      - name: Push API Docker image
+        run: docker push ${{ secrets.DOCKER_USERNAME }}/qr-code-api:${{ github.sha }}
+
+      # --- Frontend image: build → scan → push ---
+      - name: Build Frontend Docker image
         uses: docker/build-push-action@v7
         with:
           context: ./front-end-nextjs
           file: ./front-end-nextjs/Dockerfile
-          push: true
+          push: false
+          load: true
           tags: ${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}
+
+      - name: Scan Frontend image with Trivy
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}'
+          format: 'sarif'
+          output: 'trivy-frontend.sarif'
+          severity: 'CRITICAL'
+          exit-code: '1'
+
+      - name: Upload Frontend scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-frontend.sarif'
+          category: 'trivy-frontend'
+
+      - name: Push Frontend Docker image
+        run: docker push ${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -87,6 +87,7 @@ jobs:
 
       # --- Frontend image: build → scan → push ---
       - name: Build Frontend Docker image
+        id: build-frontend
         uses: docker/build-push-action@v7
         with:
           context: ./front-end-nextjs
@@ -107,7 +108,7 @@ jobs:
       - name: Scan Frontend image - report to Security tab
         id: scan-frontend
         uses: aquasecurity/trivy-action@v0.36.0
-        if: always()
+        if: always() && steps.build-frontend.result == 'success'
         with:
           image-ref: '${{ secrets.DOCKER_USERNAME }}/qr-code-frontend:${{ github.sha }}'
           format: 'sarif'

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,6 +1,9 @@
 # Start with an official Python image
 FROM python:3.9-slim
 
+# Patch OS packages to eliminate fixable CVEs flagged by image scanners
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 # Set the working directory
 WORKDIR /app
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,7 +5,7 @@ botocore==1.34.11
 click==8.1.7
 exceptiongroup==1.3.1
 fastapi==0.105.0
-h11==0.14.0
+h11==0.16.0
 idna==3.11
 jmespath==1.0.1
 pillow==10.2.0

--- a/front-end-nextjs/Dockerfile
+++ b/front-end-nextjs/Dockerfile
@@ -1,10 +1,15 @@
 FROM node:18-alpine
 
+# Patch Alpine OS packages to clear fixable CVEs (OpenSSL libcrypto3/libssl3)
+RUN apk update && apk upgrade && rm -rf /var/cache/apk/*
+
 WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm ci
+# npm install instead of npm ci because package-lock.json needs regenerating
+# after the next.js version bump. Switch back to npm ci once lock file is updated.
+RUN npm install
 
 ARG NEXT_PUBLIC_API_BASE
 ENV NEXT_PUBLIC_API_BASE=${NEXT_PUBLIC_API_BASE}

--- a/front-end-nextjs/package.json
+++ b/front-end-nextjs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.15.0",
-    "next": "14.0.4",
+    "next": "14.2.25",
     "react": "^18",
     "react-dom": "^18"
   },


### PR DESCRIPTION
Splits build-then-push into build -> scan -> push for both API and frontend images. CRITICAL CVEs fail the build before any image reaches Docker Hub. SARIF results are uploaded to the GitHub Security tab via codeql-action so findings are visible in the repo UI.