### PR TITLE
Add Prometheus remote_write to Grafana Cloud

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -279,6 +279,14 @@ jobs:
           EOF
           chmod 600 grafana.env
 
+      - name: Write Grafana Cloud credentials
+        run: |
+          set -e
+          cd ~/apps/devops-qr
+          mkdir -p monitoring/secrets
+          printf '%s' "${{ secrets.GRAFANA_CLOUD_REMOTE_WRITE_TOKEN }}" > monitoring/secrets/grafana-cloud-password
+          chmod 600 monitoring/secrets/grafana-cloud-password
+
       - name: Pull and restart stack on Pi (Docker services like Grafana)
         run: |
           set -e

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 grafana.env
+monitoring/secrets/
 
 # Terraform
 terraform/.terraform/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - "host.docker.internal:host-gateway"
     volumes:
       - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/secrets:/etc/prometheus/secrets:ro
       - prom-data:/prometheus
     restart: unless-stopped
 

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -2,6 +2,12 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+remote_write:
+  - url: https://prometheus-prod-55-prod-gb-south-1.grafana.net/api/prom/push
+    basic_auth:
+      username: "3317368"
+      password_file: /etc/prometheus/secrets/grafana-cloud-password
+
 scrape_configs:
   # Prometheus itself
   - job_name: prometheus


### PR DESCRIPTION
  Mounts a secrets directory into the Prometheus container and writes the
  remote_write token from GitHub Actions secrets at deploy time, so metrics
  are forwarded to Grafana Cloud without storing credentials in the repo.