### PR TITLE
Fix Prometheus secret file permissions (600 → 644)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -285,7 +285,7 @@ jobs:
           cd ~/apps/devops-qr
           mkdir -p monitoring/secrets
           printf '%s' "${{ secrets.GRAFANA_CLOUD_REMOTE_WRITE_TOKEN }}" > monitoring/secrets/grafana-cloud-password
-          chmod 600 monitoring/secrets/grafana-cloud-password
+          chmod 644 monitoring/secrets/grafana-cloud-password
 
       - name: Pull and restart stack on Pi (Docker services like Grafana)
         run: |


### PR DESCRIPTION
  Prometheus runs as nobody inside the container and couldn't read the
  grafana-cloud-password file written as chmod 600 by the runner (UID 1000).