### PR TITLE
  feat(monitoring): add Grafana Cloud Loki log shipping via Alloy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -287,6 +287,14 @@ jobs:
           printf '%s' "${{ secrets.GRAFANA_CLOUD_REMOTE_WRITE_TOKEN }}" > monitoring/secrets/grafana-cloud-password
           chmod 644 monitoring/secrets/grafana-cloud-password
 
+      - name: Write Grafana Cloud Loki credentials
+        run: |
+          set -e
+          cd ~/apps/devops-qr
+          mkdir -p monitoring/secrets
+          printf '%s' "${{ secrets.GRAFANA_CLOUD_LOKI_TOKEN }}" > monitoring/secrets/loki-token
+          chmod 644 monitoring/secrets/loki-token
+
       - name: Pull and restart stack on Pi (Docker services like Grafana)
         run: |
           set -e
@@ -302,6 +310,9 @@ jobs:
 
       - name: Restart Grafana to pick up provisioning
         run: docker restart grafana || true
+
+      - name: Restart Alloy to pick up config
+        run: docker restart alloy || true
 
       - name: Apply Velero metrics Service
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,22 @@ services:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     restart: unless-stopped
 
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --storage.path=/var/lib/alloy/data
+    volumes:
+      - ./monitoring/alloy-config.alloy:/etc/alloy/config.alloy:ro
+      - ./monitoring/secrets:/etc/alloy/secrets:ro
+      - /var/log:/var/log/host:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - alloy-data:/var/lib/alloy/data
+    restart: unless-stopped
+
 volumes:
   prom-data:
   grafana-data:
+  alloy-data:

--- a/monitoring/alloy-config.alloy
+++ b/monitoring/alloy-config.alloy
@@ -1,0 +1,47 @@
+// Read the Loki Cloud API token from a mounted secret file
+local.file "loki_token" {
+  filename = "/etc/alloy/secrets/loki-token"
+}
+
+// --- Host-level logs (syslog, kernel) — this is what actually
+local.file_match "host_logs" {
+  path_targets = [
+    {__path__ = "/var/log/host/syslog",   job = "syslog"},
+    {__path__ = "/var/log/host/kern.log", job = "kernel"},
+  ]
+}
+
+loki.source.file "host_logs" {
+  targets    = local.file_match.host_logs.targets
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+
+// --- Docker container logs (grafana, prometheus, qr-proxy, etc.)
+local.file_match "docker_logs" {
+  path_targets = [
+    {__path__ = "/var/lib/docker/containers/*/*.log", job = "docker"},
+  ]
+}
+
+// Docker stores each log line as a raw JSON blob — this stage
+// parses it into clean, readable text rather than dumping raw JSON
+loki.process "docker_logs" {
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+  stage.docker {}
+}
+
+loki.source.file "docker_logs" {
+  targets    = local.file_match.docker_logs.targets
+  forward_to = [loki.process.docker_logs.receiver]
+}
+
+// --- Sink: push everything to Grafana Cloud Loki
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = "https://logs-prod-035.grafana.net/loki/api/v1/push"
+    basic_auth {
+      username = "1654359"
+      password = local.file.loki_token.content
+    }
+  }
+}


### PR DESCRIPTION
  Adds the Alloy container to docker-compose.yml to ship host syslog,
  kernel logs, and Docker container logs to Grafana Cloud Loki. Deploy
  pipeline writes the GRAFANA_CLOUD_LOKI_TOKEN secret and restarts Alloy
  on every deploy so config changes are always picked up.