### PR TITLE
  fix(alloy): switch host logs to systemd journal source

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
   alloy:
     image: grafana/alloy:latest
     container_name: alloy
+    user: "0:0"
     command:
       - run
       - /etc/alloy/config.alloy
@@ -84,7 +85,9 @@ services:
     volumes:
       - ./monitoring/alloy-config.alloy:/etc/alloy/config.alloy:ro
       - ./monitoring/secrets:/etc/alloy/secrets:ro
-      - /var/log:/var/log/host:ro
+      - /var/log/journal:/var/log/journal:ro
+      - /run/log/journal:/run/log/journal:ro
+      - /etc/machine-id:/etc/machine-id:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
       - alloy-data:/var/lib/alloy/data
     restart: unless-stopped

--- a/monitoring/alloy-config.alloy
+++ b/monitoring/alloy-config.alloy
@@ -3,28 +3,24 @@ local.file "loki_token" {
   filename = "/etc/alloy/secrets/loki-token"
 }
 
-// --- Host-level logs (syslog, kernel)
-local.file_match "host_logs" {
-  path_targets = [
-    {__path__ = "/var/log/host/syslog",   job = "syslog"},
-    {__path__ = "/var/log/host/kern.log", job = "kernel"},
-  ]
+// --- Host-level logs via systemd journal — this Pi uses
+// journald, not rsyslog flat files, so we read the journal
+// directly rather than tailing /var/log/syslog (which doesn't
+// get written here)
+loki.source.journal "journal_logs" {
+  forward_to = [loki.process.journal_logs.receiver]
+  labels = {
+    job = "journal",
+  }
+  max_age = "24h"
 }
 
-loki.process "host_logs" {
+loki.process "journal_logs" {
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 
-  // Drop anything older than 24h — Loki rejects entries older than
-  // ~7 days, and without this Alloy loops forever trying to push the
-  // full historical backlog, never catching up to the present
   stage.drop {
     older_than = "24h"
   }
-}
-
-loki.source.file "host_logs" {
-  targets    = local.file_match.host_logs.targets
-  forward_to = [loki.process.host_logs.receiver]
 }
 
 // --- Docker container logs (grafana, prometheus, qr-proxy, etc.)
@@ -37,8 +33,6 @@ local.file_match "docker_logs" {
 loki.process "docker_logs" {
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 
-  // stage.docker must come first — it extracts the real timestamp
-  // from Docker's JSON wrapper, which stage.drop then checks against
   stage.docker {}
 
   stage.drop {


### PR DESCRIPTION
  The Pi uses journald, not rsyslog, so /var/log/syslog and kern.log
  were never populated — Alloy was watching empty files. Replaced the
  file-based host log source with loki.source.journal, which reads
  directly from the systemd journal. Added the required journal and
  machine-id mounts and set user: "0:0" so Alloy can read the
  root:systemd-journal owned journal files. Removed the stale /var/log
  host mount.