### PR TITLE
  fix(prometheus): drop high-cardinality container metrics before rem…

### DIFF
--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -7,6 +7,10 @@ remote_write:
     basic_auth:
       username: "3317368"
       password_file: /etc/prometheus/secrets/grafana-cloud-password
+    write_relabel_configs:
+      - source_labels: [__name__]
+        regex: "container_tasks_state|container_memory_failures_total|container_fs_reads_total|container_fs_writes_total|container_blkio_device_usage_total|container_cpu_load_average_10s|container_cpu_system_seconds_total|container_cpu_user_seconds_total|container_last_seen"
+        action: drop
 
 scrape_configs:
   # Prometheus itself


### PR DESCRIPTION
…ote write

  Adds write_relabel_configs to the Grafana Cloud remote_write entry to
  drop noisy cAdvisor metrics that add cardinality without dashboard
  value: container_tasks_state, container_memory_failures_total,
  container_fs_reads/writes_total, container_blkio_device_usage_total,
  container_cpu_load_average_10s, container_cpu_system/user_seconds_total,
  and container_last_seen.