### PR TITLE
fix: upgrade npm in frontend Dockerfile to patch bundled tar CVE

### DIFF
--- a/front-end-nextjs/Dockerfile
+++ b/front-end-nextjs/Dockerfile
@@ -2,6 +2,9 @@ FROM node:20-bookworm-slim
 
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
+# Upgrade npm to pull in a patched version of the bundled tar dependency (CVE fix).
+RUN npm install -g npm@latest
+
 WORKDIR /app
 
 COPY package*.json ./

--- a/front-end-nextjs/Dockerfile
+++ b/front-end-nextjs/Dockerfile
@@ -3,7 +3,8 @@ FROM node:20-bookworm-slim
 RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
 # Upgrade npm to pull in a patched version of the bundled tar dependency (CVE fix).
-RUN npm install -g npm@latest
+# npm@latest (v12) requires Node >=22; pin to npm@11 which supports Node 20.
+RUN npm install -g npm@11
 
 WORKDIR /app
 


### PR DESCRIPTION
The tar package bundled inside npm (/usr/local/lib/node_modules/npm/ node_modules/tar) has a CRITICAL CVE with a fix available, causing Trivy to block the build. Since tar is npm's internal dependency it cannot be patched via package.json — upgrading npm itself is the correct fix.