### PR TITLE
Remove Grafana Cloud remote_write and Loki sink

### DIFF
--- a/monitoring/alloy-config.alloy
+++ b/monitoring/alloy-config.alloy
@@ -1,8 +1,3 @@
-// Read the Loki Cloud API token from a mounted secret file
-local.file "loki_token" {
-  filename = "/etc/alloy/secrets/loki-token"
-}
-
 // --- Host-level logs via systemd journal — this Pi uses
 // journald, not rsyslog flat files, so we read the journal
 // directly rather than tailing /var/log/syslog (which doesn't
@@ -16,7 +11,7 @@ loki.source.journal "journal_logs" {
 }
 
 loki.process "journal_logs" {
-  forward_to = [loki.write.grafana_cloud_loki.receiver]
+  # forward_to = [loki.write.grafana_cloud_loki.receiver]  # TODO: point at local Loki once it's set up
 
   stage.drop {
     older_than = "24h"
@@ -31,7 +26,7 @@ local.file_match "docker_logs" {
 }
 
 loki.process "docker_logs" {
-  forward_to = [loki.write.grafana_cloud_loki.receiver]
+  # forward_to = [loki.write.grafana_cloud_loki.receiver]  # TODO: point at local Loki once it's set up
 
   stage.docker {}
 
@@ -43,15 +38,4 @@ loki.process "docker_logs" {
 loki.source.file "docker_logs" {
   targets    = local.file_match.docker_logs.targets
   forward_to = [loki.process.docker_logs.receiver]
-}
-
-// --- Sink: push everything to Grafana Cloud Loki
-loki.write "grafana_cloud_loki" {
-  endpoint {
-    url = "https://logs-prod-035.grafana.net/loki/api/v1/push"
-    basic_auth {
-      username = "1654359"
-      password = local.file.loki_token.content
-    }
-  }
 }

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -2,19 +2,6 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
-remote_write:
-  - url: https://prometheus-prod-55-prod-gb-south-1.grafana.net/api/prom/push
-    basic_auth:
-      username: "3317368"
-      password_file: /etc/prometheus/secrets/grafana-cloud-password
-    write_relabel_configs:
-      - source_labels: [__name__]
-        regex: "container_tasks_state|container_memory_failures_total|container_fs_reads_total|container_fs_writes_total|container_blkio_device_usage_total|container_cpu_load_average_10s|container_cpu_system_seconds_total|container_cpu_user_seconds_total|container_last_seen"
-        action: drop
-      - source_labels: [__name__]
-        regex: "container_memory_cache|container_memory_failcnt|container_memory_mapped_file|container_memory_max_usage_bytes|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_oom_events_total|container_spec_cpu_period|container_spec_cpu_shares|container_start_time_seconds|container_spec_memory_limit_bytes|container_spec_memory_reservation_limit_bytes|container_spec_memory_swap_limit_bytes|container_fs_inodes_free|container_fs_inodes_total|container_fs_io_current|container_fs_io_time_seconds_total|container_fs_io_time_weighted_seconds_total|container_fs_read_seconds_total|container_fs_reads_merged_total|container_fs_sector_reads_total|container_fs_sector_writes_total|container_fs_write_seconds_total|container_fs_writes_merged_total|container_fs_reads_bytes_total|container_fs_writes_bytes_total|kube_pod_status_phase|kube_pod_status_reason|container_memory_kernel_usage|kube_deployment_status_condition|node_nfs_requests_total|kube_pod_status_qos_class|kube_pod_status_ready|kube_pod_status_scheduled|kube_pod_tolerations|node_filesystem_device_error|node_filesystem_readonly|prometheus_http_requests_total|container_network_receive_errors_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_errors_total|container_network_transmit_packets_dropped_total"
-        action: drop
-
 scrape_configs:
   # Prometheus itself
   - job_name: prometheus


### PR DESCRIPTION
Reverting to local-only Grafana/Prometheus stack. Local Loki setup to follow as a separate change.