### PR TITLE
Add local Loki, fix Alloy config deploy sync, remove dead Grafana Clo…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -279,22 +279,6 @@ jobs:
           EOF
           chmod 600 grafana.env
 
-      - name: Write Grafana Cloud credentials
-        run: |
-          set -e
-          cd ~/apps/devops-qr
-          mkdir -p monitoring/secrets
-          printf '%s' "${{ secrets.GRAFANA_CLOUD_REMOTE_WRITE_TOKEN }}" > monitoring/secrets/grafana-cloud-password
-          chmod 644 monitoring/secrets/grafana-cloud-password
-
-      - name: Write Grafana Cloud Loki credentials
-        run: |
-          set -e
-          cd ~/apps/devops-qr
-          mkdir -p monitoring/secrets
-          printf '%s' "${{ secrets.GRAFANA_CLOUD_LOKI_TOKEN }}" > monitoring/secrets/loki-token
-          chmod 644 monitoring/secrets/loki-token
-
       - name: Pull and restart stack on Pi (Docker services like Grafana)
         run: |
           set -e
@@ -362,6 +346,28 @@ jobs:
             | jq -r '.data.activeTargets[]
                     | select(.labels.job=="velero" or .labels.job=="cadvisor-k8s")
                     | "\(.labels.job)\t\(.health)\t\(.discoveredLabels.__address__)\t\(.lastError)"'
+
+      - name: Ensure Alloy picked up alloy-config.alloy (reload + sanity)
+        shell: bash
+        run: |
+          set -euo pipefail
+          HOST_FILE=/home/blain/apps/devops-qr/monitoring/alloy-config.alloy
+
+          echo "---- host alloy-config.alloy grep ----"
+          grep -F 'url = "http://loki:3100/loki/api/v1/push"' "$HOST_FILE" \
+            || { echo "❌ local Loki write endpoint missing in host file"; exit 1; }
+
+          ALLOY=$(docker ps --format '{{.Names}}' | grep -i alloy | head -n1)
+
+          echo "→ Restart Alloy to pick up new config (hot-reload fails after git replaces file inode)"
+          docker restart "$ALLOY"
+          sleep 10
+
+          echo "---- container alloy-config.alloy grep ----"
+          docker exec "$ALLOY" sh -lc "grep -F 'url = \"http://loki:3100/loki/api/v1/push\"' /etc/alloy/config.alloy || echo '❌ local Loki write endpoint not found inside container'"
+
+          echo "---- alloy logs (checking for errors) ----"
+          docker logs "$ALLOY" --tail 30
 
       - name: Wait for Grafana health
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,16 @@ services:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     restart: unless-stopped
 
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    volumes:
+      - loki-data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+
   alloy:
     image: grafana/alloy:latest
     container_name: alloy
@@ -96,3 +106,4 @@ volumes:
   prom-data:
   grafana-data:
   alloy-data:
+  loki-data:

--- a/monitoring/alloy-config.alloy
+++ b/monitoring/alloy-config.alloy
@@ -11,7 +11,7 @@ loki.source.journal "journal_logs" {
 }
 
 loki.process "journal_logs" {
-  # forward_to = [loki.write.grafana_cloud_loki.receiver]  # TODO: point at local Loki once it's set up
+  forward_to = [loki.write.local_loki.receiver]
 
   stage.drop {
     older_than = "24h"
@@ -26,7 +26,7 @@ local.file_match "docker_logs" {
 }
 
 loki.process "docker_logs" {
-  # forward_to = [loki.write.grafana_cloud_loki.receiver]  # TODO: point at local Loki once it's set up
+  forward_to = [loki.write.local_loki.receiver]
 
   stage.docker {}
 
@@ -38,4 +38,11 @@ loki.process "docker_logs" {
 loki.source.file "docker_logs" {
   targets    = local.file_match.docker_logs.targets
   forward_to = [loki.process.docker_logs.receiver]
+}
+
+// --- Sink: push everything to local Loki (no auth needed, internal Docker network)
+loki.write "local_loki" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
 }

--- a/monitoring/grafana-provisioning/datasources/datasource.yml
+++ b/monitoring/grafana-provisioning/datasources/datasource.yml
@@ -1,9 +1,14 @@
 apiVersion: 1
 datasources:
   - name: Prometheus
-    uid: prometheus                
+    uid: prometheus
     type: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true
     editable: false
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false


### PR DESCRIPTION
…ud secret steps

- docker-compose.yml: add loki service (grafana/loki:latest) with persistent loki-data volume, using the image's built-in default config
- monitoring/alloy-config.alloy: fix invalid #-style comments left over from Grafana Cloud removal (Alloy uses // for comments) and wire both journal and docker log pipelines to a new loki.write "local_loki" sink pointed at http://loki:3100/loki/api/v1/push
- deploy.yml: add a verify+restart step for alloy-config.alloy mirroring the existing prometheus.yml sanity step, so config changes are actually confirmed on the Pi and Alloy is restarted to pick them up
- deploy.yml: remove the two Grafana Cloud secret-writing steps (grafana-cloud-password, loki-token) — the secrets and consumers are gone, so these were dead
- grafana-provisioning: provision Loki as a non-default Grafana data source alongside Prometheus